### PR TITLE
chore: introduce support for Dev Containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:23-alpine
+
+# Install git
+RUN apk add --no-cache git

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+// https://aka.ms/devcontainer.json
+{
+	"name": "PromptShare Dev Container",
+	"dockerComposeFile": "docker-compose.yaml",
+	"service": "promtshare",
+	"workspaceFolder": "/workspace",
+	"forwardPorts": [
+		3000,
+		27017
+	],
+	"postCreateCommand": ".devcontainer/setup-environment.sh"
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  promtshare:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: sleep infinity
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    network_mode: service:atlas
+    volumes:
+      - ..:/workspace:cached
+    
+  atlas:
+    image: mongodb/mongodb-atlas-local:8
+    hostname: atlas
+    container_name: atlas
+    restart: unless-stopped
+    volumes:
+      - atlas-data:/data/db
+
+volumes:
+  atlas-data:

--- a/.devcontainer/setup-environment.sh
+++ b/.devcontainer/setup-environment.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+echo "Running npm install..."
+npm install
+
+ENV_FILE=".env.local"
+MONGODB_URI="mongodb://localhost/?directConnection=true"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Creating $ENV_FILE..."
+  echo "MONGODB_URI=$MONGODB_URI" > "$ENV_FILE"
+else
+  echo "Updating $ENV_FILE..."
+  if grep -q "MONGODB_URI=" "$ENV_FILE"; then
+    # Update the existing MONGODB_URI line
+    sed -i "s|^MONGODB_URI=.*|MONGODB_URI=$MONGODB_URI|" "$ENV_FILE"
+  else
+    # Add the MONGODB_URI variable if it doesn't exist
+    echo "MONGODB_URI=$MONGODB_URI" >> "$ENV_FILE"
+  fi
+fi
+
+echo "$ENV_FILE setup complete."

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/README.md
+++ b/README.md
@@ -26,6 +26,39 @@ PromptShare is a modern web application that enables users to discover, create, 
 
 ## 🚀 Getting Started
 
+### Quick Setup with Dev Containers (Recommended)
+
+If you’re using VS Code, you can quickly get started using [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers):
+
+1. Clone the repository:
+```bash
+git clone https://github.com/yourusername/promptshare.git
+```
+
+2. Open the folder in VS Code with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed.
+
+3. When prompted, reopen the project in the dev container. The setup will automatically:
+- Setup a node.js development container
+- Setup a MongoDB development container
+- Install dependencies
+- Set MONGODB_URI environment variable
+
+4. Add the remaining environment variables to .env.local:
+```env
+GOOGLE_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL_INTERNAL=http://localhost:3000
+NEXTAUTH_SECRET=your_nextauth_secret
+```
+
+4. Run the development server:
+```bash
+npm run dev
+```
+
+### Manual Setup
+
 1. Clone the repository:
 ```bash
 git clone https://github.com/yourusername/promptshare.git


### PR DESCRIPTION
# Changes:

Added Dev Containers support:
- Automatically sets up the development environment, including hydrating $MONGODB_URI, to use the local atlas container.
- Installs dependencies (npm install) post-creation.

# Why?
- Simplifies the development process with containerized environments.